### PR TITLE
Testing in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,29 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Testing
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        matlab_release: [ R2020a, R2020b, R2021a ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v1
+        with:
+          release: ${{ matrix.matlab_release }}
+      - name: Run tests and generate artifacts
+        uses: matlab-actions/run-tests@v1
+        with:
+          source-folder: ./
+          test-results-junit: test_report.xml
+      - name: Upload test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: ./test_report.xml
+          check_name: Test results


### PR DESCRIPTION
This PR adds testing in GitHub Actions CI and features
* Matlab release matrix, i.e., testing multiple releases
* test result publishing with `EnricoMi/publish-unit-test-result-action`

`test_script` runs fine but `test_script_spectra` seems to fail due to:
```
Error using hmmspectramar (line 48)
      The HMM structure has more than 1 state; you need to supply Gamma in this case
```
Nevertheless, I think the testing in CI itself seems to work.

Closes #33 