### PR TITLE
Get chronectome info for all states when using vpath

### DIFF
--- a/utils/analysis/getFractionalOccupancy.m
+++ b/utils/analysis/getFractionalOccupancy.m
@@ -76,7 +76,11 @@ end
 
 if is_vpath % viterbi path
     vpath = Gamma; 
-    K = length(unique(vpath));
+    if options.dropstates==1
+        K = length(unique(vpath));
+    else
+        K = options.K;
+    end
     Gamma = zeros(length(vpath),K);
     for k = 1:K
        Gamma(vpath==k,k) = 1;   

--- a/utils/analysis/getStateIntervalTimes.m
+++ b/utils/analysis/getStateIntervalTimes.m
@@ -69,7 +69,11 @@ end
 
 if is_vpath % viterbi path
     vpath = Gamma; 
-    K = length(unique(vpath));
+    if options.dropstates==1
+        K = length(unique(vpath));
+    else
+        K = options.K;
+    end
     Gamma = zeros(length(vpath),K);
     for k = 1:K
        Gamma(vpath==k,k) = 1;   

--- a/utils/analysis/getStateLifeTimes.m
+++ b/utils/analysis/getStateLifeTimes.m
@@ -69,7 +69,11 @@ end
 
 if is_vpath % viterbi path
     vpath = Gamma; 
-    K = length(unique(vpath));
+    if options.dropstates==1
+        K = length(unique(vpath));
+    else
+        K = options.K;
+    end    
     Gamma = zeros(length(vpath),K);
     for k = 1:K
        Gamma(vpath==k,k) = 1;   

--- a/utils/analysis/getSwitchingRate.m
+++ b/utils/analysis/getSwitchingRate.m
@@ -56,7 +56,11 @@ end
 
 if is_vpath % viterbi path
     vpath = Gamma; 
-    K = length(unique(vpath));
+    if options.dropstates==1
+        K = length(unique(vpath));
+    else
+        K = options.K;
+    end
     Gamma = zeros(length(vpath),K);
     for k = 1:K
        Gamma(vpath==k,k) = 1;   


### PR DESCRIPTION
In rare cases, especially when K is large and using fMRI data, the unique value in vpath can be lesser than K. Though the code can run it's not very intuitive to determine the corresponding state of the results.

Example output for this situation after modification looks like this:
![image](https://user-images.githubusercontent.com/64966689/173251553-2907acb5-96ea-4581-84d4-eadb736bfc93.png)

The previous code is maintained for the option.dropstates==1
