### PR TITLE
Downsampling issue with Gaussian obervation model

### DIFF
--- a/utils/analysis/getFractionalOccupancy.m
+++ b/utils/analysis/getFractionalOccupancy.m
@@ -62,7 +62,8 @@ if ~isfield(options,'order') && ~isfield(options,'embeddedlags')
    options.order = (sum(T) - size(Gamma,1)) / length(T);
 end
 
-if isfield(options,'tuda') && options.tuda
+if isfield(options,'tuda') && options.tuda | ...
+        isfield(options, 'order') && options.order == 0
     T = ceil(r * T);
 elseif isfield(options,'order') && options.order > 0
     T = ceil(r * T);

--- a/utils/analysis/getStateIntervalTimes.m
+++ b/utils/analysis/getStateIntervalTimes.m
@@ -54,7 +54,14 @@ if isfield(options,'downsample') && options.downsample>0
     r = (options.downsample/options.Fs);
 end
 
-if isfield(options,'order') && options.order > 0
+if ~isfield(options,'order') && ~isfield(options,'embeddedlags')
+   options.order = (sum(T) - size(Gamma,1)) / length(T);
+end
+
+if isfield(options,'tuda') && options.tuda | ...
+        isfield(options, 'order') && options.order == 0
+    T = ceil(r * T);
+elseif isfield(options,'order') && options.order > 0
     T = ceil(r * T);
     T = T - options.order; 
 elseif isfield(options,'embeddedlags') && length(options.embeddedlags) > 1
@@ -62,9 +69,6 @@ elseif isfield(options,'embeddedlags') && length(options.embeddedlags) > 1
     d2 = max(0,options.embeddedlags(end));
     T = T - (d1+d2);
     T = ceil(r * T);
-else
-    options.order = (sum(T) - size(Gamma,1)) / length(T); 
-    T = T - options.order; 
 end
 
 if is_vpath % viterbi path

--- a/utils/analysis/getStateLifeTimes.m
+++ b/utils/analysis/getStateLifeTimes.m
@@ -55,7 +55,14 @@ if isfield(options,'downsample') && options.downsample>0
     r = (options.downsample/options.Fs);
 end
 
-if isfield(options,'order') && options.order > 0
+if ~isfield(options,'order') && ~isfield(options,'embeddedlags')
+   options.order = (sum(T) - size(Gamma,1)) / length(T);
+end
+
+if isfield(options,'tuda') && options.tuda | ...
+        isfield(options, 'order') && options.order == 0
+    T = ceil(r * T);
+elseif isfield(options,'order') && options.order > 0
     T = ceil(r * T);
     T = T - options.order; 
 elseif isfield(options,'embeddedlags') && length(options.embeddedlags) > 1
@@ -63,9 +70,6 @@ elseif isfield(options,'embeddedlags') && length(options.embeddedlags) > 1
     d2 = max(0,options.embeddedlags(end));
     T = T - (d1+d2);
     T = ceil(r * T);
-else
-    options.order = (sum(T) - size(Gamma,1)) / length(T); 
-    T = T - options.order; 
 end
 
 if is_vpath % viterbi path

--- a/utils/analysis/getSwitchingRate.m
+++ b/utils/analysis/getSwitchingRate.m
@@ -41,7 +41,14 @@ if isfield(options,'downsample') && options.downsample>0
     r = (options.downsample/options.Fs);
 end
 
-if isfield(options,'order') && options.order > 0
+if ~isfield(options,'order') && ~isfield(options,'embeddedlags')
+   options.order = (sum(T) - size(Gamma,1)) / length(T);
+end
+
+if isfield(options,'tuda') && options.tuda | ...
+        isfield(options, 'order') && options.order == 0
+    T = ceil(r * T);
+elseif isfield(options,'order') && options.order > 0
     T = ceil(r * T);
     T = T - options.order; 
 elseif isfield(options,'embeddedlags') && length(options.embeddedlags) > 1
@@ -49,9 +56,6 @@ elseif isfield(options,'embeddedlags') && length(options.embeddedlags) > 1
     d2 = max(0,options.embeddedlags(end));
     T = T - (d1+d2);
     T = ceil(r * T);
-else
-    options.order = (sum(T) - size(Gamma,1)) / length(T); 
-    T = T - options.order;     
 end
 
 if is_vpath % viterbi path


### PR DESCRIPTION
When using a gaussian model with options.downsample, T is not currently downsampled to match the length of Gamma in getFractionalOccupancies, getStateLifeTimes, getStateIntervalTimes or getSwitchingRate.